### PR TITLE
Let the propertiesupdate section support dexterity.

### DIFF
--- a/collective/jsonmigrator/properties.py
+++ b/collective/jsonmigrator/properties.py
@@ -9,7 +9,6 @@ from collective.transmogrifier.utils import defaultKeys
 
 from Acquisition import aq_base
 from ZODB.POSException import ConflictError
-from Products.Archetypes.interfaces import IBaseObject
 
 
 class Properties(object):
@@ -55,9 +54,8 @@ class Properties(object):
                 # path doesn't exist
                 yield item; continue
 
-            if not IBaseObject.providedBy(obj) or \
-               not getattr(aq_base(obj), '_delProperty', False):
-                continue
+            if not getattr(aq_base(obj), '_setProperty', False):
+                yield item; continue
 
             for pid,pvalue,ptype in item[propertieskey]:
                 if getattr(aq_base(obj), pid, None) is not None:


### PR DESCRIPTION
When using the properties updater on dexterity objects, it just used to remove the dexterity item from the pipeline, because dexterity objects do not provide Archetype's `IBaseObject`.
Because the item was not yielded when continuing the loop, it was removed from the pipeline and the object was not migrated at all.

This patch fixes the yielding problem when the object does not support properties and enables property updating for dexterity.
