### PR TITLE
Fix set datafields' filename and contenttype

### DIFF
--- a/collective/jsonmigrator/blueprints/datafields.py
+++ b/collective/jsonmigrator/blueprints/datafields.py
@@ -64,7 +64,7 @@ class DataFields(object):
                     field_value = field.get(obj)
                     if not hasattr(field_value, 'data') or value != field_value.data:
                         field.set(obj, value)
-                        obj.setFilename(item[key]['filename'])
-                        obj.setContentType(item[key]['content_type'])
+                        obj.setFilename(item[key]['filename'], fieldname)
+                        obj.setContentType(item[key]['content_type'], fieldname)
 
             yield item


### PR DESCRIPTION
Filename and contenttype should be set on the specific data field rather than the object's primary field.