### PR TITLE
Conditionally require simplejson

### DIFF
--- a/collective/jsonmigrator/blueprints/source_catalog.py
+++ b/collective/jsonmigrator/blueprints/source_catalog.py
@@ -5,11 +5,15 @@ from collective.transmogrifier.interfaces import ISectionBlueprint
 from zope.interface import classProvides, implements
 
 import base64
-import simplejson
 import threading
 import time
 import urllib
 import urllib2
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 
 class CatalogSourceSection(object):
@@ -61,7 +65,7 @@ class CatalogSourceSection(object):
         except urllib2.URLError:
             raise
 
-        self.item_paths = sorted(simplejson.loads(resp))
+        self.item_paths = sorted(json.loads(resp))
 
     def get_option(self, name, default):
         """Get an option from the request if available and fallback to the
@@ -143,8 +147,8 @@ class QueuedItemLoader(threading.Thread):
                 (item_url, str(e)))
             return None
         try:
-            item = simplejson.loads(item_json)
-        except simplejson.JSONDecodeError:
+            item = json.loads(item_json)
+        except json.JSONDecodeError:
             logger.error("Could not decode item from %s." % item_url)
             return None
         return item

--- a/collective/jsonmigrator/blueprints/source_json.py
+++ b/collective/jsonmigrator/blueprints/source_json.py
@@ -6,7 +6,11 @@ from zope.interface import classProvides
 from zope.interface import implements
 
 import os
-import simplejson
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 DATAFIELD = '_datafield_'
 
@@ -47,7 +51,7 @@ class JSONSource(object):
                 f = open(os.path.join(
                     self.path, str(item3), '%s.json' % item2
                 ))
-                item = simplejson.loads(f.read())
+                item = json.loads(f.read())
                 f.close()
 
                 yield item

--- a/collective/jsonmigrator/blueprints/source_remote.py
+++ b/collective/jsonmigrator/blueprints/source_remote.py
@@ -10,12 +10,16 @@ from zope.interface import implements
 import httplib
 import os.path
 import pickle
-import simplejson
 import string
 import urllib
 import urllib2
 import urlparse
 import xmlrpclib
+
+try:
+    import json
+except ImportError:
+    import simplejson as json
 
 _marker = object()
 MEMOIZE_PROPNAME = '_memojito_'
@@ -214,8 +218,8 @@ class RemoteSource(object):
                 return
 
             try:
-                item = simplejson.loads(item)
-            except simplejson.JSONDecodeError:
+                item = json.loads(item)
+            except json.JSONDecodeError:
                 logger.error(
                     "Could not decode item from path '%s' as JSON." % path)
                 return
@@ -240,7 +244,7 @@ class RemoteSource(object):
                     (path, subitems))
                 return
 
-            for subitem_id in simplejson.loads(subitems):
+            for subitem_id in json.loads(subitems):
                 subitem_path = path + '/' + subitem_id
 
                 if subitem_path[len(self.remote_path):]\

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ description = "JSON based migrations for Plone"
 
 requirements = [
     'setuptools',
+    'collective.transmogrifier',
     'plone.app.transmogrifier',
     'zope.app.container',
 ]

--- a/setup.py
+++ b/setup.py
@@ -6,6 +6,18 @@ from setuptools import find_packages
 version = '0.4.dev0'
 description = "JSON based migrations for Plone"
 
+requirements = [
+    'setuptools',
+    'plone.app.transmogrifier',
+    'zope.app.container',
+]
+
+try:
+    import json
+except ImportError:
+    requirements.append('simplejson')
+
+
 setup(
     name='collective.jsonmigrator',
     version=version,
@@ -33,13 +45,7 @@ setup(
     namespace_packages=['collective'],
     include_package_data=True,
     zip_safe=False,
-    install_requires=[
-        'setuptools',
-        'simplejson',
-        'collective.transmogrifier',
-        'plone.app.transmogrifier',
-        'zope.app.container',
-    ],
+    install_requires=requirements,
     entry_points="""
     [z3c.autoinclude.plugin]
     target = plone


### PR DESCRIPTION
The library simplejson is not needed in recent Python version.

If we are not using a really version of Python,
we should not depend on simplejson.

Since version 2.6, Python ships with a json library.
The code already uses it in favour of simplejson.