### PR TITLE
use string values when traversing, instead of unicode

### DIFF
--- a/collective/jsonmigrator/blueprints/workflowhistory.py
+++ b/collective/jsonmigrator/blueprints/workflowhistory.py
@@ -6,6 +6,7 @@ from collective.transmogrifier.utils import Matcher
 from DateTime import DateTime
 from Products.Archetypes.interfaces import IBaseObject
 from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import safe_unicode
 from zope.interface import classProvides
 from zope.interface import implements
 
@@ -52,7 +53,7 @@ class WorkflowHistory(object):
                 continue
 
             obj = self.context.unrestrictedTraverse(
-                item[pathkey].lstrip('/'),
+                safe_unicode(item[pathkey].lstrip('/')).encode('utf-8'),
                 None)
             if obj is None or not getattr(obj, 'workflow_history', False):
                 yield item


### PR DESCRIPTION
In some scenarios, I found that the path is a unicode string,  and when that happens the unrestrictedTraverse refuses to traverse the object so it can't change the workflow history.

This change uses safe_unicode to make the unicode -> utf8 conversion and have a sane string to call to unrestrictedTraverse
