### PR TITLE
Set default value of config fields for jsonmigrator-run view.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 0.5 (unreleased)
 ----------------
 
-- Set default value of config fields for jsonmigrator-run view.
+- Set default value of config field for jsonmigrator-run view.
   [bsuttor]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 0.5 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- Set default value of config fields for jsonmigrator-run view.
+  [bsuttor]
 
 
 0.4 (2016-05-24)

--- a/collective/jsonmigrator/helper.py
+++ b/collective/jsonmigrator/helper.py
@@ -95,7 +95,8 @@ class JSONMigratorRun(form.Form):
 
     def updateWidgets(self):
         self.label = self.request.get('form.widgets.config')
-        config = _load_config(self.request.get('form.widgets.config'))
+        self.fields['config'].field.default = self.label
+        config = _load_config(self.label)
         section = None
         for section_id in config.keys():
             tmp = config[section_id]


### PR DESCRIPTION
When POST config data is empty and GET is not empty, in some case, POST
data is get and config data value get from REQUEST is empty.