### PR TITLE
No longer depend on zope.app.container.notifyContainerModified.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Changelog
 0.5 (unreleased)
 ----------------
 
+- No longer depend on zope.app.container.notifyContainerModified.
+  Use from zope.container.contained import notifyContainerModified instead.
+  [mathias.leimgruber]
+
 - Set default value of config field for jsonmigrator-run view.
   [bsuttor]
 

--- a/collective/jsonmigrator/blueprints/order.py
+++ b/collective/jsonmigrator/blueprints/order.py
@@ -3,7 +3,7 @@ from Acquisition import aq_base
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultMatcher
-from zope.app.container.contained import notifyContainerModified
+from zope.container.contained import notifyContainerModified
 from zope.interface import classProvides, implements
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@ requirements = [
     'setuptools',
     'collective.transmogrifier>=1.5',
     'plone.app.transmogrifier',
-    'zope.app.container',
 ]
 
 try:


### PR DESCRIPTION
zope.app.container >= 4.0.0 the package depends on zope.security > 4.1 See: https://github.com/zopefoundation/zope.app.container/commit/375c776fdfcf16cb56326680f9d5e5ec203abe02

This is not compatible with Plone 4.x nor 5.x.

In Plone `notifyContainerModified` from zope.container.contained is used not from zope.app.container.

With this PR this dependency gets removed and the tope.container.contained.notifyContainerModified is used.