### PR TITLE
if certain properties (default page, others?) are unicode they cause …

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 1.1 (unreleased)
 ----------------
 
-- Nothing changed yet.
+- if certain properties (default page, others?) are unicode they cause site failures.
+  [sunew]
 
 
 1.0 (2017-12-22)

--- a/collective/jsonmigrator/blueprints/properties.py
+++ b/collective/jsonmigrator/blueprints/properties.py
@@ -66,6 +66,8 @@ class Properties(object):
                     # if object have a attribute equal to property, do nothing
                     continue
 
+                if ptype == 'string':
+                    pvalue = safe_unicode(pvalue).encode('utf-8')
                 try:
                     if obj.hasProperty(pid):
                         obj._updateProperty(pid, pvalue)


### PR DESCRIPTION
…site failures