### PR TITLE
Don't encode path in Python 3

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Don't encode path in Python 3.
+  [wesleybl]
+
 - Explicitly depends on six.
   [wesleybl]
 

--- a/setup.py
+++ b/setup.py
@@ -57,6 +57,7 @@ setup(
     install_requires=[
         "collective.transmogrifier",
         "plone.app.transmogrifier",
+        "Products.CMFPlone",
         "setuptools",
         "six",
     ],

--- a/src/collective/jsonmigrator/blueprints/datafields.py
+++ b/src/collective/jsonmigrator/blueprints/datafields.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import traverse
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implementer
 from zope.interface import provider
 
@@ -35,7 +35,7 @@ class DataFields(object):
                 yield item
                 continue
 
-            path = safe_unicode(item["_path"].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             # path doesn't exist

--- a/src/collective/jsonmigrator/blueprints/local_roles.py
+++ b/src/collective/jsonmigrator/blueprints/local_roles.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
 from AccessControl.interfaces import IRoleManager
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultKeys
 from collective.transmogrifier.utils import Matcher
 from collective.transmogrifier.utils import traverse
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implementer
 from zope.interface import provider
 
@@ -41,7 +41,7 @@ class LocalRoles(object):
                 yield item
                 continue
 
-            path = safe_unicode(item[pathkey].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             # path doesn't exist

--- a/src/collective/jsonmigrator/blueprints/mimetype.py
+++ b/src/collective/jsonmigrator/blueprints/mimetype.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultKeys
 from collective.transmogrifier.utils import Matcher
 from collective.transmogrifier.utils import traverse
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implementer
 from zope.interface import provider
 
@@ -47,7 +47,7 @@ class Mimetype(object):
                 yield item
                 continue
 
-            path = safe_unicode(item[pathkey].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             if obj is None:

--- a/src/collective/jsonmigrator/blueprints/order.py
+++ b/src/collective/jsonmigrator/blueprints/order.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultMatcher
 from collective.transmogrifier.utils import traverse
-from Products.CMFPlone.utils import safe_unicode
 from zope.container.contained import notifyContainerModified
 from zope.interface import implementer
 from zope.interface import provider
@@ -51,7 +51,7 @@ class OrderSection(object):
             for pos, key in enumerate(ordered_keys):
                 normalized_positions[key] = pos
 
-            path = safe_unicode(path.lstrip("/")).encode("ascii")
+            path = remove_first_bar(path)
             parent = traverse(self.context, path, None)
 
             if not parent:

--- a/src/collective/jsonmigrator/blueprints/owner.py
+++ b/src/collective/jsonmigrator/blueprints/owner.py
@@ -1,11 +1,11 @@
 # -*- coding: utf-8 -*-
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultKeys
 from collective.transmogrifier.utils import Matcher
 from collective.transmogrifier.utils import traverse
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implementer
 from zope.interface import provider
 
@@ -56,7 +56,7 @@ class Owner(object):
                 yield item
                 continue
 
-            path = safe_unicode(item[pathkey].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             if obj is None:

--- a/src/collective/jsonmigrator/blueprints/permissions.py
+++ b/src/collective/jsonmigrator/blueprints/permissions.py
@@ -1,12 +1,12 @@
 # -*- coding: utf-8 -*-
 from AccessControl.interfaces import IRoleManager
 from collective.jsonmigrator import logger
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultKeys
 from collective.transmogrifier.utils import Matcher
 from collective.transmogrifier.utils import traverse
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implementer
 from zope.interface import provider
 
@@ -45,7 +45,7 @@ class Permissions(object):
                 yield item
                 continue
 
-            path = safe_unicode(item[pathkey].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             if obj is None:

--- a/src/collective/jsonmigrator/blueprints/properties.py
+++ b/src/collective/jsonmigrator/blueprints/properties.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 from Acquisition import aq_base
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultKeys
@@ -46,7 +47,7 @@ class Properties(object):
                 yield item
                 continue
 
-            path = safe_unicode(item[pathkey].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             if obj is None:

--- a/src/collective/jsonmigrator/blueprints/utils.py
+++ b/src/collective/jsonmigrator/blueprints/utils.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""Functions utils."""
+from Products.CMFPlone.utils import safe_unicode
+
+
+def convert_path(path):
+    """Convert path to a valid ascii string.
+    If it contains non-ascii characters, raises an Exception."""
+    try:
+        if path.isascii():
+            return safe_unicode(path)
+    except AttributeError:
+        # BBB: Python 2 string doesn't have isascii method.
+        try:
+            return safe_unicode(path).encode("ascii")
+        except (UnicodeDecodeError, UnicodeEncodeError):
+            pass
+    _path = path
+    if not isinstance(_path, str):
+        _path = _path.encode('utf-8')
+    raise AssertionError(
+        'The path "{0}" contains non-ascii characters.'.format(
+            _path,
+        ),
+    )
+
+
+def remove_first_bar(path):
+    """Removes the first bar from a path.
+    If given a unicode, convert to string."""
+    return convert_path(path).lstrip("/")

--- a/src/collective/jsonmigrator/blueprints/workflowhistory.py
+++ b/src/collective/jsonmigrator/blueprints/workflowhistory.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
 from collective.transmogrifier.utils import defaultKeys
@@ -6,7 +7,6 @@ from collective.transmogrifier.utils import Matcher
 from collective.transmogrifier.utils import traverse
 from DateTime import DateTime
 from Products.CMFCore.utils import getToolByName
-from Products.CMFPlone.utils import safe_unicode
 from zope.interface import implementer
 from zope.interface import provider
 
@@ -61,7 +61,7 @@ class WorkflowHistory(object):
                 continue
 
             # traverse() available in version 1.5+ of collective.transmogrifier
-            path = safe_unicode(item[pathkey].lstrip("/")).encode("ascii")
+            path = remove_first_bar(item[pathkey])
             obj = traverse(self.context, path, None)
 
             if obj is None or not getattr(obj, "workflow_history", False):

--- a/src/collective/jsonmigrator/tests/test_utils.py
+++ b/src/collective/jsonmigrator/tests/test_utils.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""Tests for utils."""
+from collective.jsonmigrator.blueprints.utils import remove_first_bar
+from collective.jsonmigrator.blueprints.utils import convert_path
+
+import unittest
+
+
+class TestUtils(unittest.TestCase):
+    """Test for function of utils.py."""
+
+    def test_convert_path(self):
+        """Test function convert_path."""
+        self.assertEqual("/plone/test", convert_path("/plone/test"))
+
+    def test_convert_path_unicode(self):
+        """Validates that the convert_path function convert
+        unicode to string."""
+        path = convert_path(u"/plone/en")
+        self.assertEqual(str, type(path))
+
+    def test_convert_path_not_ascii(self):
+        """Validates that the convert_path function raises an exception when
+        it receives a path that is not an ascii."""
+        self.assertRaises(Exception, convert_path, "/plone/testç")
+
+    def test_convert_path_exception_message(self):
+        """Test exception message."""
+        ex = None
+        try:
+            convert_path(u"/plone/testç")
+        except AssertionError as e:
+            ex = e
+        self.assertEqual(
+            'The path "/plone/testç" contains non-ascii characters.',
+            str(ex),
+        )
+
+    def test_convert_path_unicode_exception_message(self):
+        """Test exception message when the path is unicode."""
+        ex = None
+        try:
+            convert_path(u"/plone/testç")
+        except AssertionError as e:
+            ex = e
+        self.assertEqual(
+            'The path "/plone/testç" contains non-ascii characters.',
+            str(ex),
+        )
+
+    def test_remove_first_bar(self):
+        """Tests if the remove_first_bar function removes the first bar."""
+        self.assertEqual("plone/en", remove_first_bar("/plone/en"))
+
+    def test_remove_first_bar_converte(self):
+        """Tests whether the remove_first_bar function
+        converts unicode to string."""
+        path = remove_first_bar(u"/plone/en")
+        self.assertEqual(str, type(path))
+
+    def test_remove_first_bar_exception_message(self):
+        """Test exception message."""
+        ex = None
+        try:
+            remove_first_bar(u"/plone/testç")
+        except AssertionError as e:
+            ex = e
+        self.assertEqual(
+            'The path "/plone/testç" contains non-ascii characters.',
+            str(ex),
+        )


### PR DESCRIPTION
This that did the path to become a byte. This caused problem in other pipelines.

The error message was also improved, when the path has non-ascii characters.