### PR TITLE
Allows use of blueprint collective.jsonmigrator.owner in dexterity objects

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,9 @@ Changelog
 1.0.2 (unreleased)
 ------------------
 
+- Allows use of blueprint collective.jsonmigrator.owner in dexterity objects.
+  [wesleybl]
+
 - Don't encode path in Python 3.
   [wesleybl]
 

--- a/src/collective/jsonmigrator/blueprints/owner.py
+++ b/src/collective/jsonmigrator/blueprints/owner.py
@@ -10,12 +10,6 @@ from zope.interface import implementer
 from zope.interface import provider
 
 
-try:
-    from Products.Archetypes.interfaces import IBaseObject
-except ImportError:
-    IBaseObject = None
-
-
 @provider(ISectionBlueprint)
 @implementer(ISection)
 class Owner(object):
@@ -61,9 +55,6 @@ class Owner(object):
 
             if obj is None:
                 yield item
-                continue
-
-            if not IBaseObject or not IBaseObject.providedBy(obj):
                 continue
 
             if item[ownerkey][0] and item[ownerkey][1]:


### PR DESCRIPTION
I tested it with dexterity and it works.