### PR TITLE
Replace deprecated base64.encodestring() with encodebytes(). Fix #45

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,7 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Add Python 3.9 base64.encodebytes() compatibility. Fix #45.
+- Add Python 3.9 base64.encodebytes() compatibility. Fix `#45 <https://github.com/collective/collective.jsonmigrator/issues/45>`_
   [shogunbr]
 
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,7 +4,8 @@ Changelog
 2.0.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add Python 3.9 base64.encodebytes() compatibility. Fix #45.
+  [shogunbr]
 
 
 2.0.0 (2021-09-22)

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -1,4 +1,5 @@
 Contributors
 ============
 
+- Leandro Koiti Sato
 - Rok Garbas, rok@garbas.si

--- a/src/collective/jsonmigrator/blueprints/source_remote.py
+++ b/src/collective/jsonmigrator/blueprints/source_remote.py
@@ -14,7 +14,6 @@ import six.moves.http_client
 import six.moves.urllib.parse
 import six.moves.urllib.request
 import six.moves.xmlrpc_client
-import string
 
 
 _marker = object()

--- a/src/collective/jsonmigrator/blueprints/source_remote.py
+++ b/src/collective/jsonmigrator/blueprints/source_remote.py
@@ -74,9 +74,9 @@ class BasicAuth(six.moves.xmlrpc_client.Transport):
             h.putheader(
                 "AUTHORIZATION",
                 "Basic %s"
-                % string.replace(
-                    encodebytes("%s:%s" % (self.username, self.password)), "\012", ""
-                ),
+                % encodebytes(
+                    ("%s:%s" % (self.username, self.password)).encode()
+                ).replace(b"\012", b"").decode()
             )
         h.endheaders()
 

--- a/src/collective/jsonmigrator/blueprints/source_remote.py
+++ b/src/collective/jsonmigrator/blueprints/source_remote.py
@@ -20,11 +20,10 @@ import string
 _marker = object()
 MEMOIZE_PROPNAME = "_memojito_"
 
-if six.PY2:
-    # BBB: base64.encodebytes doesn't exist in Python 2
-    from base64 import encodestring as encodebytes
-else:
+try:
     from base64 import encodebytes
+except ImportError:
+    from base64 import encodestring as encodebytes
 
 if six.PY2:
     # BBB: json.JSONDecodeError doesn't exist in Python 2

--- a/src/collective/jsonmigrator/blueprints/source_remote.py
+++ b/src/collective/jsonmigrator/blueprints/source_remote.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-from base64 import encodestring
 from collective.jsonmigrator import logger
 from collective.transmogrifier.interfaces import ISection
 from collective.transmogrifier.interfaces import ISectionBlueprint
@@ -20,6 +19,12 @@ import string
 
 _marker = object()
 MEMOIZE_PROPNAME = "_memojito_"
+
+if six.PY2:
+    # BBB: base64.encodebytes doesn't exist in Python 2
+    from base64 import encodestring as encodebytes
+else:
+    from base64 import encodebytes
 
 if six.PY2:
     # BBB: json.JSONDecodeError doesn't exist in Python 2
@@ -71,7 +76,7 @@ class BasicAuth(six.moves.xmlrpc_client.Transport):
                 "AUTHORIZATION",
                 "Basic %s"
                 % string.replace(
-                    encodestring("%s:%s" % (self.username, self.password)), "\012", ""
+                    encodebytes("%s:%s" % (self.username, self.password)), "\012", ""
                 ),
             )
         h.endheaders()


### PR DESCRIPTION
Replace deprecated base64.encodestring() with encodebytes(). Fix #45
base64.encodestring() was removed from Python 3.9

from https://github.com/python/cpython/issues/83532:
base64.encodestring() and base64.decodestring() are aliases deprecated since Python 3.1: encodebytes() and decodebytes() should be used instead.