### PR TITLE
Fix the CI (again)

### DIFF
--- a/base.cfg
+++ b/base.cfg
@@ -112,4 +112,4 @@ collective.jsonmigrator =
 
 # keep in sync with requirements.txt
 setuptools = 42.0.2
-zc.buildout = 2.13.4
+zc.buildout = 2.13.7


### PR DESCRIPTION
Is the zc.buildout version pin in base.cfg really required?